### PR TITLE
Better defaults for suse fix

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,12 +2,26 @@ require 'spec_helper'
 describe 'cron' do
 
   platforms = {
+    'RedHat 5' =>
+      {
+        :osfamily     => 'RedHat',
+        :osrelease    => '5.5',
+        :package_name => 'crontabs',
+        :service_name => 'crond',
+      },
     'RedHat 6' =>
       {
         :osfamily     => 'RedHat',
         :osrelease    => '6.7',
         :package_name => 'crontabs',
         :service_name => 'crond',
+      },
+    'Suse 10' =>
+      {
+        :osfamily     => 'Suse',
+        :osrelease    => '10.4',
+        :package_name => 'cron',
+        :service_name => 'cron',
       },
     'Suse 11' =>
       {
@@ -149,6 +163,16 @@ describe 'cron' do
 
       it { should contain_package(v[:package_name]) }
       it { should contain_service('cron').with_name("#{v[:service_name]}") }
+      it {
+        should contain_file('crontab').with({
+          'ensure'  => 'present',
+          'path'    => '/etc/crontab',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'content' => File.read(fixtures("default_crontab-#{v[:osfamily]}-#{v[:osrelease]}")),
+        })
+      }
     end
   end
 

--- a/spec/fixtures/default_crontab-Debian-7.9
+++ b/spec/fixtures/default_crontab-Debian-7.9
@@ -1,0 +1,18 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+SHELL=/bin/bash
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+MAILTO=root
+HOME=/
+# For details see man 4 crontabs
+
+# Example of job definition:
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+

--- a/spec/fixtures/default_crontab-RedHat-5.5
+++ b/spec/fixtures/default_crontab-RedHat-5.5
@@ -1,0 +1,23 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+SHELL=/bin/bash
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+MAILTO=root
+HOME=/
+# For details see man 4 crontabs
+
+# Example of job definition:
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+
+# run-parts
+01 * * * * root run-parts /etc/cron.hourly
+02 4 * * * root run-parts /etc/cron.daily
+22 4 * * 0 root run-parts /etc/cron.weekly
+42 4 1 * * root run-parts /etc/cron.monthly

--- a/spec/fixtures/default_crontab-RedHat-6.7
+++ b/spec/fixtures/default_crontab-RedHat-6.7
@@ -1,0 +1,18 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+SHELL=/bin/bash
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+MAILTO=root
+HOME=/
+# For details see man 4 crontabs
+
+# Example of job definition:
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+

--- a/spec/fixtures/default_crontab-Suse-10.4
+++ b/spec/fixtures/default_crontab-Suse-10.4
@@ -1,0 +1,23 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+SHELL=/bin/bash
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+MAILTO=root
+HOME=/
+# For details see man 4 crontabs
+
+# Example of job definition:
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+
+# run-parts
+01 * * * * root run-parts /etc/cron.hourly
+02 4 * * * root run-parts /etc/cron.daily
+22 4 * * 0 root run-parts /etc/cron.weekly
+42 4 1 * * root run-parts /etc/cron.monthly

--- a/spec/fixtures/default_crontab-Suse-11.3
+++ b/spec/fixtures/default_crontab-Suse-11.3
@@ -1,0 +1,22 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+SHELL=/bin/bash
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+MAILTO=root
+HOME=/
+# For details see man 4 crontabs
+
+# Example of job definition:
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+
+#
+# check scripts in cron.hourly, cron.daily, cron.weekly, and cron.monthly
+#
+-*/15 * * * *   root  test -x /usr/lib/cron/run-crons && /usr/lib/cron/run-crons >/dev/null 2>&1

--- a/spec/fixtures/default_crontab-Suse-12.1
+++ b/spec/fixtures/default_crontab-Suse-12.1
@@ -1,0 +1,22 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+SHELL=/bin/bash
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+MAILTO=root
+HOME=/
+# For details see man 4 crontabs
+
+# Example of job definition:
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+
+#
+# check scripts in cron.hourly, cron.daily, cron.weekly, and cron.monthly
+#
+-*/15 * * * *   root  test -x /usr/lib/cron/run-crons && /usr/lib/cron/run-crons >/dev/null 2>&1

--- a/templates/crontab.erb
+++ b/templates/crontab.erb
@@ -32,24 +32,16 @@ HOME=/
 <% end -%>
 <% if (( @osfamily == 'RedHat' ) and ( @operatingsystemrelease =~ /^5/ )) or (( @osfamily == 'Suse' ) and ( @operatingsystemrelease =~ /^10/ )) -%>
 # run-parts
-<% if @cron_hourly_path == nil -%>
-01 * * * * root run-parts /etc/cron.hourly
-<% else -%>
+<% if @cron_hourly_path != nil -%>
 01 * * * * root run-parts <%= @cron_hourly_path %>
 <% end -%>
-<% if @cron_daily_path == nil -%>
-02 4 * * * root run-parts /etc/cron.daily
-<% else -%>
+<% if @cron_daily_path != nil -%>
 02 4 * * * root run-parts <%= @cron_daily_path %>
 <% end -%>
-<% if @cron_weekly_path == nil -%>
-22 4 * * 0 root run-parts /etc/cron.weekly
-<% else -%>
+<% if @cron_weekly_path != nil -%>
 22 4 * * 0 root run-parts <%= @cron_weekly_path %>
 <% end -%>
-<% if @cron_monthly_path == nil -%>
-42 4 1 * * root run-parts /etc/cron.monthly
-<% else -%>
+<% if @cron_monthly_path != nil -%>
 42 4 1 * * root run-parts <%= @cron_monthly_path %>
 <% end -%>
 <% elsif @osfamily == 'Suse' and (( @operatingsystemrelease =~ /^11/ ) or ( @operatingsystemrelease =~ /^12/ )) -%>

--- a/templates/crontab.erb
+++ b/templates/crontab.erb
@@ -30,3 +30,31 @@ HOME=/
 <% end -%>
 <% end -%>
 <% end -%>
+<% if (( @osfamily == 'RedHat' ) and ( @operatingsystemrelease =~ /^5/ )) or (( @osfamily == 'Suse' ) and ( @operatingsystemrelease =~ /^10/ )) -%>
+# run-parts
+<% if @cron_hourly_path == nil -%>
+01 * * * * root run-parts /etc/cron.hourly
+<% else -%>
+01 * * * * root run-parts <%= @cron_hourly_path %>
+<% end -%>
+<% if @cron_daily_path == nil -%>
+02 4 * * * root run-parts /etc/cron.daily
+<% else -%>
+02 4 * * * root run-parts <%= @cron_daily_path %>
+<% end -%>
+<% if @cron_weekly_path == nil -%>
+22 4 * * 0 root run-parts /etc/cron.weekly
+<% else -%>
+22 4 * * 0 root run-parts <%= @cron_weekly_path %>
+<% end -%>
+<% if @cron_monthly_path == nil -%>
+42 4 1 * * root run-parts /etc/cron.monthly
+<% else -%>
+42 4 1 * * root run-parts <%= @cron_monthly_path %>
+<% end -%>
+<% elsif @osfamily == 'Suse' and (( @operatingsystemrelease =~ /^11/ ) or ( @operatingsystemrelease =~ /^12/ )) -%>
+#
+# check scripts in cron.hourly, cron.daily, cron.weekly, and cron.monthly
+#
+-*/15 * * * *   root  test -x /usr/lib/cron/run-crons && /usr/lib/cron/run-crons >/dev/null 2>&1
+<% end -%>


### PR DESCRIPTION
Previous defaults included an empty /etc/crontab for SuSE causing periodic cron jobs not to run. Added better defaults for SuSE10-12.

Note: Spec test and fixture file included for Debian though I currently don't have access to a Debian system and don't know what the defaults should be.