### PR TITLE
Modernize the testing rig

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,42 @@
+---
+AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  Exclude:
+    - vendor/**/*
+    - pkg/**/*
+    - spec/fixtures/**/*
+
+# Cop's to ignore
+
+# With this enabled it suggests a change that will break the Gemfile
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+# This is a good idea, but does not line up the rest of the lines making it
+# harder to read
+Style/IndentHash:
+  Enabled: false
+
+Style/Next:
+  Enabled: false
+
+# If enabled, this cop makes it harder to understand the logic
+Style/NonNilCheck:
+  Enabled: false
+
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+# Cop's that require ruby >= 1.9
+Style/HashSyntax:
+  Enabled: false
+
+Style/BracesAroundHashParameters:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ env:
     - PUPPET_GEM_VERSION="~> 4.2.0"
     - PUPPET_GEM_VERSION="~> 4.3.0"
     - PUPPET_GEM_VERSION="~> 4.4.0"
-    - PUPPET_GEM_VERSION="~> 4"
+    - PUPPET_GEM_VERSION="~> 4.5.0"
     - PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
 
 sudo: false
 
-script: 'bundle exec metadata-json-lint metadata.json && bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
+script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
 
 matrix:
   fast_finish: true
@@ -54,7 +54,7 @@ matrix:
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4.4.0"
     - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4"
+      env: PUPPET_GEM_VERSION="~> 4.5.0"
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,20 +1,37 @@
 source 'https://rubygems.org'
 
-if puppetversion = ENV['PUPPET_GEM_VERSION']
-  gem 'puppet', puppetversion, :require => false
+if ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', ENV['PUPPET_GEM_VERSION'], :require => false
 else
   gem 'puppet', :require => false
 end
 
 gem 'metadata-json-lint'
-gem 'puppetlabs_spec_helper', '>= 0.1.0'
-gem 'puppet-lint', '>= 1.0.0'
+gem 'puppetlabs_spec_helper', '>= 1.1.1'
 gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet'
+gem 'puppet-lint', '>= 1.0', '< 3.0' # change to '~> 2.0' once the plugins got updated
+gem 'puppet-lint-absolute_classname-check'
+gem 'puppet-lint-alias-check'
+gem 'puppet-lint-empty_string-check'
+gem 'puppet-lint-file_ensure-check'
+gem 'puppet-lint-file_source_rights-check'
+gem 'puppet-lint-fileserver-check'
+gem 'puppet-lint-leading_zero-check'
+gem 'puppet-lint-spaceship_operator_without_tag-check'
+gem 'puppet-lint-trailing_comma-check'
+gem 'puppet-lint-undef_in_function-check'
+gem 'puppet-lint-unquoted_string-check'
+gem 'puppet-lint-variable_contains_upcase'
 
-# rspec must be v2 for ruby 1.8.7
 if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  # rspec must be v2 for ruby 1.8.7
   gem 'rspec', '~> 2.0'
-  # rake >= 11 does not support ruby 1.8.7
+  # rake >=11 does not support ruby 1.8.7
   gem 'rake', '~> 10.0'
+end
+
+if RUBY_VERSION < '2.0'
+  # json 2.x requires ruby 2.0. Lock to 1.8
+  gem 'json', '~> 1.8'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 

--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -4,7 +4,7 @@
 #
 define cron::fragment (
   $ensure       = 'absent',
-  $content      = '',
+  $content      = undef,
   $owner        = 'root',
   $group        = 'root',
   $mode         = 'USE_DEFAULTS',
@@ -44,7 +44,7 @@ define cron::fragment (
     $mode_real = $mode
   }
 
-  include cron
+  include ::cron
 
   validate_re($ensure_real, '^(absent|file|present)$', "cron::fragment::ensure is ${ensure} and must be absent, file or present")
   if is_string($content_real) == false { fail('cron::fragment::content must be a string') }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,15 +123,18 @@ class cron (
   if $cron_deny_users != undef {
     validate_array($cron_deny_users)
   }
-  if $cron_files != undef {
-    validate_hash($cron_files)
-    create_resources(cron::fragment,$cron_files)
-  }
+
   if $crontab_tasks != undef {
     validate_hash($crontab_tasks)
   }
+
   if $crontab_vars != undef {
     validate_hash($crontab_vars)
+  }
+
+  if $cron_files != undef {
+    validate_hash($cron_files)
+    create_resources(cron::fragment,$cron_files)
   }
 
   validate_absolute_path($cron_allow_path)
@@ -192,11 +195,11 @@ class cron (
       File[cron_daily],
       File[cron_weekly],
       File[cron_monthly],
-    ]
+    ],
   }
 
   file { 'crontab':
-    ensure  => present,
+    ensure  => file,
     path    => $crontab_path,
     owner   => $crontab_owner,
     group   => $crontab_group,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -72,7 +72,7 @@ describe 'cron' do
     }
     it {
       should contain_file('crontab').with({
-        'ensure'  => 'present',
+        'ensure'  => 'file',
         'path'    => '/etc/crontab',
         'owner'   => 'root',
         'group'   => 'root',

--- a/spec/defines/fragment_spec.rb
+++ b/spec/defines/fragment_spec.rb
@@ -13,7 +13,7 @@ describe 'cron::fragment' do
         'owner'   => 'root',
         'group'   => 'root',
         'mode'    => '0755',
-        'content' => '',
+        'content' => nil,
         'require' => 'File[crontab]',
       })
     }


### PR DESCRIPTION
- Keep supporting Ruby 1.8.7
- Use puppetlabs_spec_helper >= 1.1.1
- Support more explicit versions of Puppet v4
- Add puppet-lint community plugins