### PR TITLE
Puppetlabs ratings fix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,10 +116,10 @@ class cron (
     }
   }
 
-  case $periodic_jobs_manage {
-    true, 'true':   { $periodic_jobs_manage_bool = true } # lint:ignore:quoted_booleans
-    false, 'false': { $periodic_jobs_manage_bool = false } # lint:ignore:quoted_booleans
-    default:        { fail('cron::periodic_jobs_manage is not a boolean.') }
+  if is_bool($periodic_jobs_manage) == true {
+    $periodic_jobs_manage_bool = $periodic_jobs_manage
+  } else {
+    $periodic_jobs_manage_bool = str2bool($periodic_jobs_manage)
   }
 
   if $periodic_jobs_manage_bool == true {

--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,35 @@
   "source": "git://github.com/Ericsson/puppet-module-cron.git",
   "project_page": "https://github.com/Ericsson/puppet-module-cron",
   "issues_url": "https://github.com/Ericsson/puppet-module-cron/issues",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6"
+      ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "10",
+        "11",
+        "12"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "12.04"
+      ]
+    }
+  ],
   "description": "Manage cron",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}


### PR DESCRIPTION
Adding operatingsystem_support to metadata.json and remove puppet lint issue.
This to increase the puppetlabs ratings 